### PR TITLE
updating dirs in make

### DIFF
--- a/config/make.js
+++ b/config/make.js
@@ -171,7 +171,7 @@ const patterns = [
  * to write files to, it should be added here.
  */
 const dirs = {
-  'base': '../',
+  'base': Path.join(__dirname, '../'),
   'src': 'src',
   'config': 'config',
   'views': 'views'

--- a/scripts/make.js
+++ b/scripts/make.js
@@ -114,7 +114,7 @@ function makeFile(dir, filetype, pattern, callback) {
  */
 function makeDefaults(type, pattern, callback) {
   let relative = Path.join(config.dirs.src, type);
-  let absolute = Path.join(__dirname, config.dirs.base, relative, pattern);
+  let absolute = Path.join(config.dirs.base, relative, pattern);
 
   fnDirectory(absolute, type, pattern, (success) => {
     if (success) {


### PR DESCRIPTION
Minor edit. Whenever using the `make` command, it'd point to the patterns-framework directory rather than the current project root directory.