### PR TITLE
Update versioning an publishing workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,9 @@
   },
   "scripts": {
     "start": "cross-env NODE_ENV=development cross-env PORT=7070 concurrently \"scripts/default.js -w\" \"scripts/serve.js -w\" -p \"none\"",
-    "preversion": "cross-env NODE_ENV=production scripts/default.js",
-    "prepublishOnly": "cross-env NODE_ENV=production scripts/default.js",
+    "default": "cross-env NODE_ENV=production scripts/default.js",
+    "version": "npm run default && git add .",
+    "prepublishOnly": "git push && git push --tags",
     "publish": "cross-env NODE_ENV=production scripts/publish.js"
   },
   "bin": {

--- a/readme.md
+++ b/readme.md
@@ -14,8 +14,9 @@ If you are using any of the [optional dependencies](#optional-dependencies) used
 
     "scripts": {
       "start": "cross-env NODE_ENV=development cross-env PORT=7070 concurrently \"pttrn default -w\" \"pttrn serve -w\" -p \"none\"",
-      "preversion": "cross-env NODE_ENV=production pttrn default",
-      "prepublishOnly": "cross-env NODE_ENV=production pttrn default",
+      "default": "cross-env NODE_ENV=production pttrn default",
+      "version": "npm run default && git add .",
+      "prepublishOnly": "git push && git push --tags",
       "publish": "cross-env NODE_ENV=production pttrn publish"
     },
 
@@ -27,11 +28,11 @@ Start the development server (assuming you've added the npm scripts above to you
 
     pttrn {{ command }}
 
-Versioning uses the default `npm version` command. This will run the `preversion` command in the recommended NPM Scripts.
+Versioning uses the default `npm version` command. This will run the `version` command in the recommended NPM Scripts.
 
     npm version {{ major/minor/patch }}
 
-Publishing to the registry uses the default `npm publish` command. This will run `prepublishOnly` and `publish` commands in the recommended NPM Scripts above as well. Publishing requires a new tag/version before publishing.
+Publishing to the registry uses the default `npm publish` command. This will run `prepublishOnly` and `publish` commands in the recommended NPM Scripts above as well which push all tags to GitHub. Publishing requires a new tag/version before publishing.
 
     npm publish
 


### PR DESCRIPTION
I refined the scripts a little bit in order to make it easier to publish. There were some issues with the previous scripts.

Now, running...

```
npm version
```

Will bump the package.json version, compile the css, js, and html, then stage and commit the changes.

Then, all that would need to be done to publish this new version is...

```
npm publish
```

This will push all tags in the repo to GitHub then publish the latest tag/version to the NPM registry. Happy to accept suggestions to make it easier!