### PR TITLE
Fix name mismatch in the Rollup config for Toggle

### DIFF
--- a/config/rollup.js
+++ b/config/rollup.js
@@ -99,13 +99,13 @@ const modules = [
     plugins: rollup.dist,
     output: [
       {
-        name: 'Forms',
+        name: 'Toggle',
         file: `${process.env.PWD}/dist/utilities/toggle/toggle.iffe.js`,
         format: 'iife',
         strict: rollup.strict
       },
       {
-        name: 'Forms',
+        name: 'Toggle',
         file: `${process.env.PWD}/dist/utilities/toggle/toggle.common.js`,
         format: 'cjs',
         strict: rollup.strict

--- a/dist/utilities/toggle/toggle.iffe.js
+++ b/dist/utilities/toggle/toggle.iffe.js
@@ -1,4 +1,4 @@
-var Forms = (function () {
+var Toggle = (function () {
   'use strict';
 
   /**


### PR DESCRIPTION
There was a mismatch in the Rollup.js configuration that let to the
Toggle component to be instantiated into a variable Forms. For example:

  <script>
      var toggle = new Forms();
  </script>

This commit will fix this an when instantiating it will be

  new Toggle();

Cheers!